### PR TITLE
riscv_asm.h: Use CSR_<FOO> instead of <foo> for csr_read()

### DIFF
--- a/include/sbi/riscv_asm.h
+++ b/include/sbi/riscv_asm.h
@@ -10,6 +10,8 @@
 #ifndef __RISCV_ASM_H__
 #define __RISCV_ASM_H__
 
+#include <sbi/riscv_encoding.h>
+
 #ifdef __ASSEMBLY__
 #define __ASM_STR(x)	x
 #else
@@ -144,17 +146,17 @@ do {								\
 
 static inline int misa_extension(char ext)
 {
-	return csr_read(misa) & (1 << (ext - 'A'));
+	return csr_read(CSR_MISA) & (1 << (ext - 'A'));
 }
 
 static inline int misa_xlen(void)
 {
-	return ((long)csr_read(misa) < 0) ? 64 : 32;
+	return ((long)csr_read(CSR_MISA) < 0) ? 64 : 32;
 }
 
 static inline void misa_string(char *out, unsigned int out_sz)
 {
-	unsigned long i, val = csr_read(misa);
+	unsigned long i, val = csr_read(CSR_MISA);
 
 	for (i = 0; i < 26; i++) {
 		if (val & (1 << i)) {

--- a/lib/sbi_misaligned_ldst.c
+++ b/lib/sbi_misaligned_ldst.c
@@ -28,7 +28,7 @@ int sbi_misaligned_load_handler(u32 hartid, ulong mcause,
 	union reg_data val;
 	ulong mstatus = csr_read(mstatus);
 	ulong insn = get_insn(regs->mepc, &mstatus);
-	ulong addr = csr_read(mtval);
+	ulong addr = csr_read(CSR_MTVAL);
 	int i, fp = 0, shift = 0, len = 0;
 
 	if ((insn & INSN_MASK_LW) == INSN_MATCH_LW) {
@@ -114,7 +114,7 @@ int sbi_misaligned_store_handler(u32 hartid, ulong mcause,
 	union reg_data val;
 	ulong mstatus = csr_read(mstatus);
 	ulong insn = get_insn(regs->mepc, &mstatus);
-	ulong addr = csr_read(mtval);
+	ulong addr = csr_read(CSR_MTVAL);
 	int i, len = 0;
 
 	val.data_ulong = GET_RS2(insn, regs);

--- a/lib/sbi_trap.c
+++ b/lib/sbi_trap.c
@@ -89,9 +89,9 @@ int sbi_trap_redirect(struct sbi_trap_regs *regs,
 		return SBI_ENOTSUPP;
 
 	/* Update S-mode exception info */
-	csr_write(stval, tval);
-	csr_write(sepc, epc);
-	csr_write(scause, cause);
+	csr_write(CSR_STVAL, tval);
+	csr_write(CSR_SEPC, epc);
+	csr_write(CSR_SCAUSE, cause);
 
 	/* Set MEPC to S-mode exception vector base */
 	regs->mepc = csr_read(stvec);
@@ -183,6 +183,6 @@ void sbi_trap_handler(struct sbi_trap_regs *regs,
 
 trap_error:
 	if (rc) {
-		sbi_trap_error(msg, rc, hartid, mcause, csr_read(mtval), regs);
+		sbi_trap_error(msg, rc, hartid, mcause, csr_read(CSR_MTVAL), regs);
 	}
 }


### PR DESCRIPTION
Some toolchains might not have all the CSRs available (as seen with
GCC 7.2). So, instead use the defined CSR_ values.

I think we might want to move over all uses to these instead over time?

Signed-off-by: Olof Johansson <olof@lixom.net>