### PR TITLE
Makefile: add 'make run' command for virtualized platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,21 @@ install_targets-y += install_libplatsbi
 install_targets-y += install_firmwares
 endif
 
+# Convenient "make run" command for emulated platforms
+.PHONY: run
+run: all
+ifneq ($(platform-runcmd),)
+	$(platform-runcmd)
+else
+ifdef PLATFORM
+	@echo Platform $(PLATFORM) doesn't specify a run command
+	@false
+else
+	@echo Run command only available when targeting a platform
+	@false
+endif
+endif
+
 # Rule for "make install"
 .PHONY: install
 install: $(install_targets-y)

--- a/platform/qemu/sifive_u/config.mk
+++ b/platform/qemu/sifive_u/config.mk
@@ -13,6 +13,9 @@ platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
 platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
 platform-ldflags-y =
 
+platform-runcmd = qemu-system-riscv64 -M sifive_u -m 256M -display none -serial stdio \
+        -kernel build/platform/qemu/sifive_u/firmware/fw_payload.elf
+
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y
 PLATFORM_SERIAL_SIFIVE_UART=y

--- a/platform/qemu/virt/config.mk
+++ b/platform/qemu/virt/config.mk
@@ -13,6 +13,9 @@ platform-cflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
 platform-asflags-y =-mabi=lp64 -march=rv64imafdc -mcmodel=medany
 platform-ldflags-y =
 
+platform-runcmd = qemu-system-riscv64 -M virt -m 256M -display none -serial stdio \
+        -kernel build/platform/qemu/virt/firmware/fw_payload.elf
+
 # Common drivers to enable
 PLATFORM_IRQCHIP_PLIC=y
 PLATFORM_SERIAL_UART8250=y


### PR DESCRIPTION
Makes for easy and quick build-run one-stop command.

For now only added for qemu targets.

Example output:

```
olofj-mbp:opensbi olofj$ make -s run
Run command only available when targeting a platform
make: *** [run] Error 1
olofj-mbp:opensbi olofj$
```
And with a platform:
```
olofj-mbp:opensbi olofj$ make PLATFORM=qemu/virt run
qemu-system-riscv64 -M virt -m 256M -display none -serial stdio -kernel build/platform/qemu/virt/firmware/fw_payload.elf

OpenSBI v0.1 (Feb  4 2019 22:56:41)
[...]
```


Signed-off-by: Olof Johansson <olof@lixom.net>