### PR TITLE
lib: Fix buffer overflow issue in FDT fixups

### DIFF
--- a/include/sbi_utils/fdt/fdt_fixup.h
+++ b/include/sbi_utils/fdt/fdt_fixup.h
@@ -13,7 +13,7 @@
  * Fix up the CPU node in the device tree
  *
  * This routine updates the "status" property of a CPU node in the device tree
- * to "disabled" if that hart is in disabled state in OpenSBI.
+ * to "" if that hart is in disabled state in OpenSBI.
  *
  * It is recommended that platform codes call this helper in their final_init()
  *

--- a/lib/utils/fdt/fdt_domain.c
+++ b/lib/utils/fdt/fdt_domain.c
@@ -142,7 +142,7 @@ static int __fixup_disable_devices(void *fdt, int doff, int roff,
 		if (coff < 0)
 			return coff;
 
-		fdt_setprop_string(fdt, coff, "status", "disabled");
+		fdt_setprop_string(fdt, coff, "status", "");
 	}
 
 	return 0;

--- a/lib/utils/fdt/fdt_fixup.c
+++ b/lib/utils/fdt/fdt_fixup.c
@@ -46,8 +46,7 @@ void fdt_cpu_fixup(void *fdt)
 		mmu_type = fdt_getprop(fdt, cpu_offset, "mmu-type", &len);
 		if (!sbi_domain_is_assigned_hart(dom, hartid) ||
 		    !mmu_type || !len)
-			fdt_setprop_string(fdt, cpu_offset, "status",
-					   "disabled");
+			fdt_setprop_string(fdt, cpu_offset, "status", "");
 	}
 }
 


### PR DESCRIPTION
We encounter a bug in Linux kernel that some cores are failed to be disabled and some cores are crashed during smpboot. And the root cause of the issue is the SBI FDT fixups.
The FDT fixup functions should modify a device tree node with the value bounded by its original boundary. That's why the official method to make an Linux kernel OF device node unavailable is to make its length to be 0. As strlen("") is surely less than strlen("okay"), and strlen("disabled") breaks the runtime FDT.

This patch fixes the buffer overflow issue in the FDT fixups.

Reference: **linux/drivers/of/base.c __of_device_is_available()**