### PR TITLE
SBI: add a workaround for clang

### DIFF
--- a/lib/sbi/sbi_ecall.c
+++ b/lib/sbi/sbi_ecall.c
@@ -98,9 +98,11 @@ int sbi_ecall_handler(struct sbi_trap_regs *regs)
 	struct sbi_ecall_extension *ext;
 	unsigned long extension_id = regs->a7;
 	unsigned long func_id = regs->a6;
-	struct sbi_trap_info trap = {0};
+	struct sbi_trap_info trap;
 	unsigned long out_val = 0;
 	bool is_0_1_spec = 0;
+
+	sbi_memset(&trap, 0, sizeof(trap));
 
 	ext = sbi_ecall_find_extension(extension_id);
 	if (ext && ext->handle) {

--- a/lib/sbi/sbi_hart.c
+++ b/lib/sbi/sbi_hart.c
@@ -337,7 +337,9 @@ done:
 static unsigned long hart_pmp_get_allowed_addr(void)
 {
 	unsigned long val = 0;
-	struct sbi_trap_info trap = {0};
+	struct sbi_trap_info trap;
+
+	sbi_memset(&trap, 0, sizeof(trap));
 
 	csr_write_allowed(CSR_PMPADDR0, (ulong)&trap, PMP_ADDR_MASK);
 	if (!trap.cause) {
@@ -352,8 +354,10 @@ static unsigned long hart_pmp_get_allowed_addr(void)
 static int hart_pmu_get_allowed_bits(void)
 {
 	unsigned long val = ~(0UL);
-	struct sbi_trap_info trap = {0};
+	struct sbi_trap_info trap;
 	int num_bits = 0;
+
+	sbi_memset(&trap, 0, sizeof(trap));
 
 	/**
 	 * It is assumed that platforms will implement same number of bits for
@@ -382,9 +386,11 @@ static int hart_pmu_get_allowed_bits(void)
 
 static void hart_detect_features(struct sbi_scratch *scratch)
 {
-	struct sbi_trap_info trap = {0};
+	struct sbi_trap_info trap;
 	struct hart_features *hfeatures;
 	unsigned long val;
+
+	sbi_memset(&trap, 0, sizeof(trap));
 
 	/* Reset hart features */
 	hfeatures = sbi_scratch_offset_ptr(scratch, hart_features_offset);

--- a/lib/sbi/sbi_pmu.c
+++ b/lib/sbi/sbi_pmu.c
@@ -539,8 +539,10 @@ unsigned long sbi_pmu_num_ctr(void)
 
 int sbi_pmu_ctr_get_info(uint32_t cidx, unsigned long *ctr_info)
 {
-	union sbi_pmu_ctr_info cinfo = {0};
+	union sbi_pmu_ctr_info cinfo;
 	struct sbi_scratch *scratch = sbi_scratch_thishart_ptr();
+
+	sbi_memset(&cinfo, 0, sizeof(cinfo));
 
 	/* Sanity check. Counter1 is not mapped at all */
 	if (cidx >= total_ctrs || cidx == 1)


### PR DESCRIPTION
When building with clang with `-Os -ffreestanding`, it seems that clang
improperly forms a call to `memset`.  With `-ffreestanding`, the C
standard as per Clause 4, the compiler cannot necessarily assume that
anything beyond:
- float.h
- iso646.h
- limits.h
- stdalign.h
- stdarg.h
- stdbool.h
- stddef.h
- stdint.h
- stdnoreturn.h
- fenv.h
- math.h
and the numeric conversion functions of stdlib.h.

This change explicitly converts the memset into a `sbi_memset`.  The
overhead here should be minimal, namely an extra jump for the memset
rather than an inline unrolled implementation.