### PR TITLE
Ensure reproducible builds regardless of build path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ CFLAGS		+=	$(GENFLAGS)
 CFLAGS		+=	$(platform-cflags-y)
 CFLAGS		+=	-fno-pie -no-pie
 CFLAGS		+=	$(firmware-cflags-y)
+CFLAGS		+=	-ffile-prefix-map=$(CURDIR)=.
 
 CPPFLAGS	+=	$(GENFLAGS)
 CPPFLAGS	+=	$(platform-cppflags-y)


### PR DESCRIPTION
Upstream commit 12753d22563f7d2d01f2c6644c7b66b06eb5c90f introduced
uses of __FILE__ which may result in the build path getting embedded
into the resulting binary.

The -ffile-prefix-map argument is available in gcc 8 and clang 10, which can be used to strip out the absolute part of the path from the artifacts the compiler produces.

https://reproducible-builds.org/docs/build-path/

Signed-off-by: Vagrant Cascadian <vagrant@reproducible-builds.org>