### PR TITLE
docs/platform: spike: Improve examples

### DIFF
--- a/docs/platform/spike.md
+++ b/docs/platform/spike.md
@@ -43,7 +43,18 @@ make PLATFORM=generic FW_PAYLOAD_PATH=<linux_build_directory>/arch/riscv/boot/Im
 
 Run:
 ```
-spike --initrd <path_to_cpio_ramdisk> build/platform/generic/firmware/fw_payload.elf
+spike -m256 \
+	--initrd <path_to_cpio_ramdisk> \
+	--bootargs 'root=/dev/ram rw console=hvc0 earlycon=sbi' \
+	build/platform/generic/firmware/fw_payload.elf
+```
+or
+```
+spike -m256 \
+	--kernel <linux_build_directory>/arch/riscv/boot/Image \
+	--initrd <path_to_cpio_ramdisk> \
+	--bootargs 'root=/dev/ram rw console=hvc0 earlycon=sbi' \
+	build/platform/generic/firmware/fw_jump.elf
 ```
 
 Execution on QEMU RISC-V 64-bit


### PR DESCRIPTION
I mainly use Spike rather than QEMU for small tests and I find that setting up Spike (with OpenSBI + Linux + initramfs) is not easy enough.

This commit makes Spike examples usable as QEMU ones.
This is not a full tutorial (totally lacks initramfs, which is out of scope in the OpenSBI documentation) but better than nothing.