### PR TITLE
Provide flexibility to specify OpenSBI FW_TEXT_START during compilation

### DIFF
--- a/platform/generic/config.mk
+++ b/platform/generic/config.mk
@@ -18,7 +18,9 @@ platform-runcmd = qemu-system-riscv$(PLATFORM_RISCV_XLEN) -M virt -m 256M \
   -nographic -bios $(build_dir)/platform/generic/firmware/fw_payload.elf
 
 # Blobs to build
-FW_TEXT_START=0x80000000
+ifeq ($(FW_TEXT_START), )
+  FW_TEXT_START=0x80000000
+endif
 FW_DYNAMIC=y
 FW_JUMP=y
 ifeq ($(PLATFORM_RISCV_XLEN), 32)


### PR DESCRIPTION
This changes is to provide flexibility for platform that does not use the default FW_TEXT_START.
If FW_TEXT_START is not specified, default value will be used.

Signed-off-by: Wei Liang Lim <weiliang.lim@linux.starfivetech.com>