### PR TITLE
fix detection of csr count

### DIFF
--- a/lib/sbi/sbi_hart.c
+++ b/lib/sbi/sbi_hart.c
@@ -405,7 +405,7 @@ static void hart_detect_features(struct sbi_scratch *scratch)
 {
 	struct sbi_trap_info trap = {0};
 	struct hart_features *hfeatures;
-	unsigned long val;
+	unsigned long val, tmp_val;
 
 	/* Reset hart features */
 	hfeatures = sbi_scratch_offset_ptr(scratch, hart_features_offset);
@@ -414,14 +414,14 @@ static void hart_detect_features(struct sbi_scratch *scratch)
 	hfeatures->mhpm_count = 0;
 
 #define __check_csr(__csr, __rdonly, __wrval, __field, __skip)	\
-	val = csr_read_allowed(__csr, (ulong)&trap);			\
+	tmp_val = csr_read_allowed(__csr, (ulong)&trap);			\
 	if (!trap.cause) {						\
 		if (__rdonly) {						\
 			(hfeatures->__field)++;				\
 		} else {						\
 			csr_write_allowed(__csr, (ulong)&trap, __wrval);\
 			if (!trap.cause) {				\
-				if (csr_swap(__csr, val) == __wrval)	\
+				if (csr_swap(__csr, tmp_val) == __wrval)	\
 					(hfeatures->__field)++;		\
 				else					\
 					goto __skip;			\


### PR DESCRIPTION
The check of csr_swap() would always pass if '__wrval' is
the macro substitution of the variable 'val' in check_csr(),
which renders hfeatures->*_count incorrect.

Use 'tmp_val' instead of 'val' to keep the temporary value of
CSRs to avoid this problem.