### PR TITLE
sbi: scale the stack according to pointer size

### DIFF
--- a/include/sbi/sbi_platform.h
+++ b/include/sbi/sbi_platform.h
@@ -129,7 +129,15 @@ struct sbi_platform_operations {
 };
 
 /** Platform default per-HART stack size for exception/interrupt handling */
+#if !defined(SBI_PLATFORM_DEFAULT_HART_STACK_SIZE)
+#if __riscv_xlen == 32
 #define SBI_PLATFORM_DEFAULT_HART_STACK_SIZE	8192
+#elif __riscv_xlen == 64
+#define SBI_PLATFORM_DEFAULT_HART_STACK_SIZE	(2 * 8192)
+#else
+#define SBI_PLATFORM_DEFAULT_HART_STACK_SIZE	(4 * 8192)
+#endif
+#endif
 
 /** Representation of a platform */
 struct sbi_platform {


### PR DESCRIPTION
Scale the default stack size according to the pointer size.  This is
important to accommodate the space required for stack allocation of the
device tree structures which scale according to the pointer size.

In the case that the default stack size is insufficient, ensure that
there is an escape hatch for users to override the default stack size at
compile time.