### PR TITLE
Makefile: bugfix for handling platform paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifdef PLATFORM_DIR
     platform_parent_dir=$(platform_dir_path)
   else
     PLATFORM=$(shell basename $(platform_dir_path))
-    platform_parent_dir=$(shell dirname $(shell realpath $(platform_dir_path)))    
+    platform_parent_dir=$(shell realpath $(platform_dir_path)/..)
   endif
 else
  platform_parent_dir=$(src_dir)/platform

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifdef PLATFORM_DIR
     platform_parent_dir=$(platform_dir_path)
   else
     PLATFORM=$(shell basename $(platform_dir_path))
-    platform_parent_dir=$(subst $(PLATFORM),,$(platform_dir_path))
+    platform_parent_dir=$(shell dirname $(shell realpath $(platform_dir_path)))    
   endif
 else
  platform_parent_dir=$(src_dir)/platform


### PR DESCRIPTION
If the path where this repo is located contains the platform name on it, the original Makefile replaced its occurrences from the path making it an invalid path. This commit prevents this behavior replacing only the last part of the path as originally intended.

Signed-off-by: Alejandro Cabrera Aldaya <aldaya@gmail.com>