### PR TITLE
Makefile: replace `echo` with `printf` for compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ $(KCONFIG_CONFIG): $(platform_src_dir)/configs/$(PLATFORM_DEFCONFIG) $(platform_
 
 $(KCONFIG_AUTOCMD): $(KCONFIG_CONFIG)
 	$(CMD_PREFIX)mkdir -p $(KCONFIG_DIR)
-	$(CMD_PREFIX)echo -n "$(KCONFIG_CONFIG): " > $(KCONFIG_AUTOCMD)
+	$(CMD_PREFIX)printf "%s: " $(KCONFIG_CONFIG) > $(KCONFIG_AUTOCMD)
 	$(CMD_PREFIX)cat $(KCONFIG_AUTOLIST) | tr '\n' ' ' >> $(KCONFIG_AUTOCMD)
 
 include $(KCONFIG_CONFIG)


### PR DESCRIPTION
I don't know why but `echo -n` didn't work for me. macOS supports the `-n` option but it doesn't work in the makefile. What it does instead is it literally writes `-n` to the file and then also leaves a newline at the end.

I'm using GNU Make 4.4 (`gmake` from Homebrew).