### PR TITLE
DBCN: check A2 register in RV64.

### DIFF
--- a/lib/sbi/sbi_ecall_dbcn.c
+++ b/lib/sbi/sbi_ecall_dbcn.c
@@ -34,11 +34,14 @@ static int sbi_ecall_dbcn_handler(unsigned long extid, unsigned long funcid,
 		 * Based on above, we simply fail if the upper 32bits of
 		 * the physical address (i.e. a2 register) is non-zero on
 		 * RV32.
+                 *
+                 * Analogously, we fail if the upper 64bit of the
+                 * physical address (i.e. a2 register) is non-zero on
+                 * RV64.
 		 */
-#if __riscv_xlen == 32
 		if (regs->a2)
 			return SBI_ERR_FAILED;
-#endif
+
 		if (!sbi_domain_check_addr_range(sbi_domain_thishart_ptr(),
 					regs->a1, regs->a0, smode,
 					SBI_DOMAIN_READ|SBI_DOMAIN_WRITE))


### PR DESCRIPTION
I am probably missing something, but in RV64 DBCN extension we ignore A2 register, i.e. the highest XLEN bits of the physical address.

While I do not expect to make the physical address a 128-bit register, nevertheless the spec (both section 3.2 and Chapter 12, I see no mention of RV64 not requiring to interpret A2 as a high bits of the physical address.

This PR fixes this by returning an error in case, similarly to RV32, the A2 is non-zero.