### PR TITLE
Fix comment errors

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -210,7 +210,7 @@ _relocate_done:
 
 	/* At this point we are running from link address */
 
-	/* Reset all registers for boot HART */
+	/* Reset all registers except ra, a0, a1 and a2 for boot HART */
 	li	ra, 0
 	call	_reset_regs
 
@@ -437,7 +437,7 @@ _wait_for_boot_hart:
 	bne	t0, t1, _wait_for_boot_hart
 
 _start_warm:
-	/* Reset all registers for non-boot HARTs */
+	/* Reset all registers except ra, a0, a1 and a2 for boot HART and non-boot HARTs */
 	li	ra, 0
 	call	_reset_regs
 


### PR DESCRIPTION
First, When we call **_reset_regs**, it'll reset all registers except ra, a0, a1 and a2;
Second, both boot HART and non-boot HARTs will execute the **_start_warm** function. Therefore, **_reset_regs** called in **_start_warm** will reset all registers except ra, a0, a1 and a2 for boot HART and non-boot HARTs.