### PR TITLE
fix section type for firmware dynamic

### DIFF
--- a/firmware/fw_dynamic.S
+++ b/firmware/fw_dynamic.S
@@ -129,7 +129,7 @@ fw_options:
 	REG_L	a0, (a0)
 	ret
 
-	.section .entry, "ax", %progbits
+	.section .data, "aw", %progbits
 	.align 3
 _dynamic_next_arg1:
 	RISCV_PTR 0x0


### PR DESCRIPTION
This section is only intended to hold data, and should not be executable.