### PR TITLE
lib: sbi_domain: Fix PMP condition for addresses

### DIFF
--- a/lib/sbi/sbi_domain.c
+++ b/lib/sbi/sbi_domain.c
@@ -749,7 +749,7 @@ int sbi_domain_init(struct sbi_scratch *scratch, u32 cold_hartid)
 		return SBI_EINVAL;
 	}
 
-	if ((scratch->fw_start & (scratch->fw_rw_offset - 1)) != 0) {
+	if ((scratch->fw_start & ((scratch->fw_rw_offset >> 2) - 1)) != 0) {
 		sbi_printf("%s: fw_start and fw_rw_offset not aligned\n",
 			   __func__);
 		return SBI_EINVAL;


### PR DESCRIPTION
In order to put an address/size into an NAPOT PMP region, the address needs to be aligned to the size shifted two to the right.

Example:
fw_start: 0x80040000
fw_size:  0x00040000
PMP address: 0x80040000 | (0x00040000 >> 2)
fw_size is valid, but not in the current implementation

Fixes issue #345 