### PR TITLE
create a variable for the ext data array size

### DIFF
--- a/include/sbi/sbi_hart.h
+++ b/include/sbi/sbi_hart.h
@@ -74,6 +74,7 @@ struct sbi_hart_ext_data {
 };
 
 extern const struct sbi_hart_ext_data sbi_hart_ext[];
+extern const int sbi_hart_ext_size;
 
 /*
  * Smepmp enforces access boundaries between M-mode and

--- a/lib/sbi/sbi_hart.c
+++ b/lib/sbi/sbi_hart.c
@@ -668,6 +668,8 @@ const struct sbi_hart_ext_data sbi_hart_ext[] = {
 	__SBI_HART_EXT_DATA(smcdeleg, SBI_HART_EXT_SMCDELEG),
 };
 
+const int sbi_hart_ext_size = sizeof(sbi_hart_ext) / sizeof(sbi_hart_ext[0]);
+
 /**
  * Get the hart extensions in string format
  *

--- a/lib/utils/fdt/fdt_helper.c
+++ b/lib/utils/fdt/fdt_helper.c
@@ -401,7 +401,7 @@ static int fdt_parse_isa_one_hart(const char *isa, unsigned long *extensions)
 				continue;			\
 			}
 
-		for (j = 0; j < SBI_HART_EXT_MAX; j++) {
+		for (j = 0; j < sbi_hart_ext_size; j++) {
 			set_multi_letter_ext(sbi_hart_ext[j].name,
 					     sbi_hart_ext[j].id);
 		}


### PR DESCRIPTION
On some platforms, opensbi fails as the loop in
fdt_parse_isa_one_hart is for 32 items,
and the array is only 15 at present.