### PR TITLE
sbi/sbi_types.h: Don't unconditionally define '__always_inline'

### DIFF
--- a/include/sbi/sbi_types.h
+++ b/include/sbi/sbi_types.h
@@ -69,7 +69,10 @@ typedef uint64_t		be64_t;
 #define __packed		__attribute__((packed))
 #define __noreturn		__attribute__((noreturn))
 #define __aligned(x)		__attribute__((aligned(x)))
+
+#ifndef __always_inline
 #define __always_inline	inline __attribute__((always_inline))
+#endif
 
 #define likely(x) __builtin_expect((x), 1)
 #define unlikely(x) __builtin_expect((x), 0)


### PR DESCRIPTION
This is to fix update opensbi to upstream build for coreboot. https://qa.coreboot.org/job/coreboot-gerrit/257449/testReport/junit/(root)/clang/EMULATION_QEMU_RISCV_RV64_/