### PR TITLE
lib: sbi: fix number of PMP entries detection

### DIFF
--- a/lib/sbi/sbi_hart.c
+++ b/lib/sbi/sbi_hart.c
@@ -817,7 +817,7 @@ static int hart_detect_features(struct sbi_scratch *scratch)
 		} else {						\
 			csr_write_allowed(__csr, &trap, __wrval);	\
 			if (!trap.cause) {				\
-				if (csr_swap(__csr, oldval) == __wrval)	\
+				if ((csr_swap(__csr, oldval) & __wrval) == __wrval)	\
 					(hfeatures->__field)++;		\
 				else					\
 					goto __skip;			\


### PR DESCRIPTION
CSR_PMPADDRn lower bits may read all-0 or all-1, depending on the configuration. For TOR it is all-0, for NAPOT - all-1.

Thus if PMP entry was pre-configured as NAPOT, original code would stop scanning because value read back not equal to the written one.

Mask lower bits before comparison to fix this