### PR TITLE
docs: add example of building the Linux kernel

### DIFF
--- a/docs/platform/qemu_virt.md
+++ b/docs/platform/qemu_virt.md
@@ -56,7 +56,13 @@ qemu-system-riscv64 -M virt -m 256M -nographic \
 **Linux Kernel Payload**
 
 Note: We assume that the Linux kernel is compiled using
-*arch/riscv/configs/defconfig*.
+*arch/riscv/configs/defconfig*. The kernel must be a flattened image (a file called `Image`) rather than an ELF (`vmlinux`).
+
+Example of building a Linux kernel:
+```
+make ARCH=riscv CROSS_COMPILE=riscv64-linux- defconfig
+make ARCH=riscv CROSS_COMPILE=riscv64-linux- Image
+```
 
 Build:
 ```


### PR DESCRIPTION
Slightly expand the QEMU docs to explain how to build the flat Linux kernel image.

This might seem really obvious to you pros, but I spend a good 20 minutes googling how to do this and completely failing - there doesn't seem to be much documentation on this stuff, at least not easily googleable. Almost everything uses `vmlinux`. I also tried reading the Linux makefiles and things like `make arch/riscv/boot/Image` which you'd think would work but doesn't. I never would have guessed `make Image`.