### PR TITLE
lib: sbi: Fix behavior on platform without HART protection

### DIFF
--- a/lib/sbi/sbi_init.c
+++ b/lib/sbi/sbi_init.c
@@ -394,7 +394,7 @@ static void __noreturn init_coldboot(struct sbi_scratch *scratch, u32 hartid)
 	 * detected, M-mode access to the S/U space will be rescinded.
 	 */
 	rc = sbi_hart_protection_configure(scratch);
-	if (rc) {
+	if (rc && rc != SBI_EINVAL) {
 		sbi_printf("%s: hart isolation configure failed (error %d)\n",
 			   __func__, rc);
 		sbi_hart_hang();
@@ -473,7 +473,7 @@ static void __noreturn init_warm_startup(struct sbi_scratch *scratch,
 	 * detected, M-mode access to the S/U space will be rescinded.
 	 */
 	rc = sbi_hart_protection_configure(scratch);
-	if (rc)
+	if (rc && rc != SBI_EINVAL)
 		sbi_hart_hang();
 
 	count = sbi_scratch_offset_ptr(scratch, init_count_offset);
@@ -494,7 +494,7 @@ static void __noreturn init_warm_resume(struct sbi_scratch *scratch,
 		sbi_hart_hang();
 
 	rc = sbi_hart_protection_configure(scratch);
-	if (rc)
+	if (rc && rc != SBI_EINVAL)
 		sbi_hart_hang();
 
 	sbi_hsm_hart_resume_finish(scratch, hartid);


### PR DESCRIPTION
The commit 42139bb9b7dc ("lib: sbi: Replace sbi_hart_pmp_xyz() and sbi_hart_map/unmap_addr()") changed logic by calling sbi_hart_protection_configure(). But when protection doesn't exist the function is returning SBI_EINVAL.
But on systems without protection this is correct configuration that's why do not hang when system don't have any HART protection.

I only tested cold boot but likely that issue is also related to warm case that's why I have fixed that too.
Another solution could be obviously also by fixing by returning 0 in case that no protection is available.