### PR TITLE
lib: utils/mailbox: clamp RPMI shmem queue name to RPMI_NAME_CHARS_MAX

### DIFF
--- a/lib/utils/mailbox/fdt_mailbox_rpmi_shmem.c
+++ b/lib/utils/mailbox/fdt_mailbox_rpmi_shmem.c
@@ -663,7 +663,10 @@ static int rpmi_shmem_transport_init(struct rpmi_shmem_mbox_controller *mctl,
 		if (!name || (name && len < 0))
 			return len;
 
+		if (len >= RPMI_NAME_CHARS_MAX)
+			len = RPMI_NAME_CHARS_MAX - 1;
 		sbi_memcpy(qctx->name, name, len);
+		qctx->name[len] = '\0';
 
 		/* store the index as queue_id */
 		qctx->queue_id = qid;


### PR DESCRIPTION
## Problem

`rpmi_shmem_transport_init()` copies a device-tree `reg-names` string into `qctx->name` (a `char[RPMI_NAME_CHARS_MAX=16]` buffer) using `sbi_memcpy(qctx->name, name, len)` without validating the length. If the device tree supplies a `reg-names` string longer than 15 characters, the copy overflows the fixed-size 16-byte buffer.

This is the same class of buffer-length issue as #416.

## Reproduction

A device-tree node with a `reg-names` entry longer than 15 characters (e.g., `"a2p-db-and-shmem"` at 17 bytes including null) will overflow the 16-byte `qctx->name` buffer.

## Fix

Add a length clamp before the `sbi_memcpy`:

```c
if (len >= RPMI_NAME_CHARS_MAX)
    len = RPMI_NAME_CHARS_MAX - 1;
sbi_memcpy(qctx->name, name, len);
qctx->name[len] = '\0';
```

The name is truncated if it exceeds 15 characters, and the buffer is always null-terminated.

## Test

The RPMI mailbox subsystem does not have a standalone unit-test suite, but the fix is validated by review against the existing pattern in the codebase (e.g., the `rpmi_shmem_transport_init()` function itself already validates the `reg-names` count against `RPMI_QUEUE_IDX_MAX_COUNT`).

## Limitations

- The `RPMI_NAME_CHARS_MAX` constant is defined in `include/sbi_utils/mailbox/rpmi_msgprot.h` as 16. The existing code already uses this constant for the buffer declaration.
- No new sbi_unit test is added because the RPMI subsystem currently has no unit-test infrastructure in the tree.
- Cross-compilation was not performed (requires RISC-V toolchain).